### PR TITLE
iOS: support for building using buildbot recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,13 @@ else ifneq (,$(findstring ios,$(platform)))
    ifeq ($(IOSSDK),)
       IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
    endif
-   CC = cc -arch armv7 -isysroot $(IOSSDK)
-   CXX = c++ -arch armv7 -isysroot $(IOSSDK)
+   ifeq ($(platform), ios-arm64)
+     CC = cc -arch arm64 -isysroot $(IOSSDK)
+     CXX = c++ -arch arm64 -isysroot $(IOSSDK)
+   else
+     CC = cc -arch armv7 -isysroot $(IOSSDK)
+     CXX = c++ -arch armv7 -isysroot $(IOSSDK)
+   endif
    IPHONEMINVER :=
    ifeq ($(platform),$(filter $(platform),ios9 ios-arm64))
       IPHONEMINVER = -miphoneos-version-min=8.0
@@ -105,7 +110,7 @@ else ifneq (,$(findstring ios,$(platform)))
       IPHONEMINVER = -miphoneos-version-min=5.0
    endif
    LDFLAGS += $(IPHONEMINVER)
-   FLAGS += $(IPHONEMINVER)
+   FLAGS += $(IPHONEMINVER) -DIOS -DHAVE_POSIX_MEMALIGN
    CC += $(IPHONEMINVER)
    CXX += $(IPHONEMINVER)
 


### PR DESCRIPTION
Fix iOS build with compiler flags to support libco, ios-arm64 support