### PR TITLE
[WiiU] Aroma CFW Compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,13 +221,13 @@ else ifneq (,$(filter $(platform), ngc wii wiiu))
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
    ENDIANNESS_DEFINES += -DGEKKO -mcpu=750 -meabi -mhard-float -DMSB_FIRST -DBYTE_ORDER=BIG_ENDIAN
-   FLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+   FLAGS += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
    EXTRA_INCLUDES := -I$(DEVKITPRO)/libogc/include
    STATIC_LINKING = 1
 
    # Nintendo WiiU
    ifneq (,$(findstring wiiu,$(platform)))
-      ENDIANNESS_DEFINES += -DWIIU -DHW_RVL -mwup
+      ENDIANNESS_DEFINES += -DWIIU -DHW_RVL
 
    # Nintendo Wii
    else ifneq (,$(findstring wii,$(platform)))


### PR DESCRIPTION
This update will make the Core compatible with the soon to be released Aroma Retroarch port.
This should also be Tiramisu safe too so should be good to merge :)